### PR TITLE
Add calendar view and modularize todo UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,157 +1,143 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import type { CSSProperties, FormEvent } from 'react';
+import Calendar from './components/Calendar';
+import TodoList from './components/TodoList';
 import { pullTodos } from './GetCanvasTodo';
+import type { RootTodo, TodoItem } from './types';
 
-function App() {
-  const [todos, setTodos] = useState<any[]>([]);
+type ViewMode = 'list' | 'calendar';
+
+const App = () => {
+  const [todos, setTodos] = useState<TodoItem[]>([]);
   const [newTodo, setNewTodo] = useState('');
+  const [newDueDate, setNewDueDate] = useState('');
   const [deletingId, setDeletingId] = useState<number | null>(null);
+  const [viewMode, setViewMode] = useState<ViewMode>('list');
 
-  // Load Canvas assignments
   useEffect(() => {
     pullTodos()
       .then((canvasTodos) => {
-        const mapped = canvasTodos.map((t: any) => ({
-          id: t.assignment.id,
-          text: t.assignment.name,
-          due_at: t.assignment.due_at,
+        const mapped: TodoItem[] = canvasTodos.map((todo: RootTodo) => ({
+          id: todo.assignment.id,
+          text: todo.assignment.name,
+          due_at: todo.assignment.due_at ?? undefined,
           completed: false,
+          created_at: todo.assignment.created_at,
         }));
+
         setTodos(mapped);
       })
-      .catch((err: Error) => console.error(err));
+      .catch((error: Error) => {
+        console.error('Failed to load Canvas assignments', error);
+      });
   }, []);
 
-  // Add your own task
-  const addTodo = (e: React.FormEvent) => {
-    e.preventDefault();
+  const addTodo = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     if (!newTodo.trim()) return;
 
-    const todo = {
+    const dueDateIso = newDueDate ? new Date(`${newDueDate}T12:00:00`).toISOString() : undefined;
+
+    const todo: TodoItem = {
       id: Date.now(),
-      text: newTodo,
+      text: newTodo.trim(),
       completed: false,
       created_at: new Date().toISOString(),
+      due_at: dueDateIso,
     };
 
-    setTodos([todo, ...todos]);
+    setTodos((prev) => [todo, ...prev]);
     setNewTodo('');
+    setNewDueDate('');
   };
 
   const toggleTodo = (id: number) => {
-    setTodos(
-      todos.map((todo) =>
-        todo.id === id ? { ...todo, completed: !todo.completed } : todo
-      )
+    setTodos((prev) =>
+      prev.map((todo) =>
+        todo.id === id
+          ? {
+              ...todo,
+              completed: !todo.completed,
+            }
+          : todo,
+      ),
     );
   };
 
   const deleteTodo = (id: number) => {
     setDeletingId(id);
     setTimeout(() => {
-      setTodos(todos.filter((todo) => todo.id !== id));
+      setTodos((prev) => prev.filter((todo) => todo.id !== id));
       setDeletingId(null);
     }, 300);
   };
 
+  const toggleView = () => {
+    setViewMode((prev) => (prev === 'list' ? 'calendar' : 'list'));
+  };
+
+  const sliderStyle: CSSProperties = {
+    width: 'calc(50% - 0.25rem)',
+    transform: viewMode === 'calendar' ? 'translateX(100%)' : 'translateX(0)',
+  };
+
   return (
-    <div className="min-h-screen w-full bg-[#fefcff] relative p-4 md:p-8 overflow-hidden">
+    <div className="relative min-h-screen w-full overflow-hidden bg-[#fefcff] p-4 md:p-8">
       <div
-        className="absolute inset-0 z-0 animate-gradientMove"
+        className="animate-gradientMove absolute inset-0 z-0"
         style={{
           backgroundImage: `
             radial-gradient(circle at 30% 70%, rgba(173, 216, 230, 0.35), transparent 60%),
             radial-gradient(circle at 70% 30%, rgba(255, 182, 193, 0.4), transparent 60%)`,
         }}
       />
-      <div className="relative z-10 mx-auto max-w-2xl">
-        <h1 className="mb-8 text-4xl font-bold text-center text-transparent bg-clip-text bg-gradient-to-r from-pink-300 to-purple-300 drop-shadow-lg animate-fadeDown">
-          Kota's ToDo List
-        </h1>
 
-        {/* Add Todo Form */}
-        <form onSubmit={addTodo} className="mb-8">
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={newTodo}
-              onChange={(e) => setNewTodo(e.target.value)}
-              placeholder="Add a new task..."
-              className="flex-1 p-3 rounded-xl border backdrop-blur-lg transition-all duration-300 border-white/20 bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30 text-pink-900/90 placeholder-pink-700/60"
+      <div className="relative z-10 mx-auto flex w-full max-w-4xl flex-col items-stretch">
+        <header className="mb-10 text-center">
+          <h1 className="mb-3 text-4xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-pink-300 to-purple-300 drop-shadow-lg animate-fadeDown">
+            Kota&apos;s Planner
+          </h1>
+          <p className="text-sm text-pink-900/70">
+            Toggle between a focused task list and a dreamy calendar overview to keep everything on track.
+          </p>
+        </header>
+
+        <div className="mb-8 flex justify-center">
+          <button
+            type="button"
+            onClick={toggleView}
+            aria-pressed={viewMode === 'calendar'}
+            className="relative flex w-full max-w-xs items-center justify-between rounded-full border border-white/30 bg-white/20 p-1 text-sm font-semibold text-pink-900/70 shadow-inner backdrop-blur"
+          >
+            <span
+              className="absolute top-1 bottom-1 left-1 rounded-full bg-gradient-to-r from-pink-400/80 to-purple-400/80 shadow-lg transition-transform duration-300 ease-out"
+              style={sliderStyle}
             />
-            <button
-              type="submit"
-              className="px-6 py-2 bg-pink-600/80 hover:bg-pink-700/90 text-white rounded-xl backdrop-blur-lg border border-white/20 hover:border-white/30 transition-all duration-300 shadow-lg hover:shadow-[0_0_20px_rgba(236,72,153,0.4)] active:scale-95"
-            >
-              Add
-            </button>
-          </div>
-        </form>
-
-        {/* Todo List */}
-        <div className="space-y-3">
-          {todos.map((todo) => (
-            <div
-              key={todo.id}
-              className={`p-4 rounded-2xl backdrop-blur-lg transition-all duration-300 flex items-start border border-white/20
-                ${deletingId === todo.id ? 'animate-fadeOut' : 'animate-fadeIn'}
-                ${todo.completed
-                  ? 'bg-green-100/30 hover:shadow-lg hover:shadow-green-500/10 text-green-900/90'
-                  : 'bg-white/30 hover:bg-white/40 hover:shadow-lg hover:shadow-pink-500/10 text-pink-900/90'}
-              `}
-            >
-              <input
-                type="checkbox"
-                checked={todo.completed}
-                onChange={() => toggleTodo(todo.id)}
-                className="mt-1 w-5 h-5 text-pink-400 rounded-full border-pink-200 transition-transform duration-200 focus:ring-pink-300"
-              />
-              <div className="flex-1 ml-3">
-                <p
-                  className={`transition-all duration-300 ${
-                    todo.completed
-                      ? 'line-through text-green-900/60 animate-completePulse'
-                      : ''
-                  }`}
-                >
-                  {todo.text}
-                </p>
-                <p className="mt-1 text-xs text-pink-900/70">
-                  {new Date(todo.due_at || todo.created_at).toLocaleDateString()}
-                </p>
-              </div>
-              <button
-                onClick={() => deleteTodo(todo.id)}
-                className="p-1 rounded-lg transition-colors duration-200 text-pink-700/70 hover:text-pink-900 hover:bg-pink-100/50"
-                aria-label="Delete todo"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="w-5 h-5"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                  />
-                </svg>
-              </button>
-            </div>
-          ))}
+            <span className={`relative z-10 flex-1 text-center ${viewMode === 'list' ? 'text-white' : ''}`}>List</span>
+            <span className={`relative z-10 flex-1 text-center ${viewMode === 'calendar' ? 'text-white' : ''}`}>
+              Calendar
+            </span>
+          </button>
         </div>
 
-        {/* Stats */}
-        {todos.length > 0 && (
-          <div className="mt-6 text-sm text-center text-gray-500 animate-fadeUp">
-            {todos.filter((t) => t.completed).length} of {todos.length} tasks completed
-          </div>
+        {viewMode === 'list' ? (
+          <TodoList
+            todos={todos}
+            newTodo={newTodo}
+            newDueDate={newDueDate}
+            deletingId={deletingId}
+            onNewTodoChange={setNewTodo}
+            onDueDateChange={setNewDueDate}
+            onAddTodo={addTodo}
+            onToggleTodo={toggleTodo}
+            onDeleteTodo={deleteTodo}
+          />
+        ) : (
+          <Calendar todos={todos} onToggleTodo={toggleTodo} />
         )}
       </div>
     </div>
   );
-}
+};
 
 export default App;

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,0 +1,240 @@
+import { useMemo, useState } from 'react';
+import type { TodoItem } from '../types';
+
+interface CalendarProps {
+  todos: TodoItem[];
+  onToggleTodo: (id: number) => void;
+}
+
+const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+const toDateKey = (date: Date) => {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const startOfMonth = (date: Date) => new Date(date.getFullYear(), date.getMonth(), 1);
+
+const sameDay = (a: Date, b: Date) =>
+  a.getFullYear() === b.getFullYear() &&
+  a.getMonth() === b.getMonth() &&
+  a.getDate() === b.getDate();
+
+const getTodoDueDate = (todo: TodoItem): Date | null => {
+  if (!todo.due_at) return null;
+  const parsed = new Date(todo.due_at);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed;
+};
+
+const Calendar = ({ todos, onToggleTodo }: CalendarProps) => {
+  const [currentMonth, setCurrentMonth] = useState(() => startOfMonth(new Date()));
+
+  const calendarDays = useMemo(() => {
+    const firstDay = startOfMonth(currentMonth);
+    const lastDay = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0);
+
+    const leadingDays = firstDay.getDay();
+    const trailingDays = 6 - lastDay.getDay();
+    const totalCells = leadingDays + lastDay.getDate() + trailingDays;
+
+    const startDate = new Date(firstDay);
+    startDate.setDate(firstDay.getDate() - leadingDays);
+
+    const days: Date[] = [];
+    for (let i = 0; i < totalCells; i += 1) {
+      const day = new Date(startDate);
+      day.setDate(startDate.getDate() + i);
+      days.push(day);
+    }
+
+    return days;
+  }, [currentMonth]);
+
+  const todosByDay = useMemo(() => {
+    const grouped: Record<string, TodoItem[]> = {};
+
+    todos.forEach((todo) => {
+      const date = getTodoDueDate(todo);
+      if (!date) return;
+      const key = toDateKey(date);
+      grouped[key] = [...(grouped[key] ?? []), todo];
+    });
+
+    Object.keys(grouped).forEach((key) => {
+      grouped[key].sort((a, b) => {
+        const dateA = getTodoDueDate(a)?.getTime() ?? 0;
+        const dateB = getTodoDueDate(b)?.getTime() ?? 0;
+        if (dateA !== dateB) return dateA - dateB;
+        return a.text.localeCompare(b.text);
+      });
+    });
+
+    return grouped;
+  }, [todos]);
+
+  const undatedTodos = useMemo(
+    () => todos.filter((todo) => !todo.due_at || Number.isNaN(new Date(todo.due_at).getTime())),
+    [todos],
+  );
+
+  const today = new Date();
+  const monthLabel = currentMonth.toLocaleDateString(undefined, {
+    month: 'long',
+    year: 'numeric',
+  });
+
+  const goToPreviousMonth = () => {
+    setCurrentMonth((prev) => new Date(prev.getFullYear(), prev.getMonth() - 1, 1));
+  };
+
+  const goToNextMonth = () => {
+    setCurrentMonth((prev) => new Date(prev.getFullYear(), prev.getMonth() + 1, 1));
+  };
+
+  const goToCurrentMonth = () => {
+    const now = new Date();
+    setCurrentMonth(new Date(now.getFullYear(), now.getMonth(), 1));
+  };
+
+  return (
+    <div className="animate-fadeIn space-y-6">
+      <div className="rounded-3xl border border-white/30 bg-white/40 p-6 shadow-xl backdrop-blur-xl">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-sm uppercase tracking-[0.35em] text-pink-900/60">Monthly Overview</p>
+            <h2 className="text-3xl font-semibold text-transparent bg-clip-text bg-gradient-to-r from-pink-400 to-purple-400 drop-shadow-sm">
+              {monthLabel}
+            </h2>
+          </div>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={goToPreviousMonth}
+              className="rounded-full border border-white/30 bg-white/40 p-2 text-pink-700/80 transition-all duration-200 hover:bg-white/70 hover:text-pink-900"
+              aria-label="Previous month"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                <path
+                  fillRule="evenodd"
+                  d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 11-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+            <button
+              type="button"
+              onClick={goToCurrentMonth}
+              className="rounded-full border border-white/40 bg-gradient-to-r from-pink-300/70 to-purple-300/70 px-4 py-2 text-sm font-semibold text-white shadow-md transition-all duration-200 hover:shadow-lg hover:shadow-pink-500/20"
+            >
+              Today
+            </button>
+            <button
+              type="button"
+              onClick={goToNextMonth}
+              className="rounded-full border border-white/30 bg-white/40 p-2 text-pink-700/80 transition-all duration-200 hover:bg-white/70 hover:text-pink-900"
+              aria-label="Next month"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                <path
+                  fillRule="evenodd"
+                  d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-6 grid grid-cols-7 gap-2 text-center text-xs font-semibold uppercase tracking-wide text-pink-600/80">
+          {dayNames.map((day) => (
+            <div key={day} className="rounded-xl bg-white/40 py-2 backdrop-blur">
+              {day}
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-2 grid grid-cols-7 gap-2">
+          {calendarDays.map((date) => {
+            const key = toDateKey(date);
+            const items = todosByDay[key] ?? [];
+            const isCurrentMonth =
+              date.getMonth() === currentMonth.getMonth() && date.getFullYear() === currentMonth.getFullYear();
+            const isToday = sameDay(date, today);
+
+            return (
+              <div
+                key={key}
+                className={`flex min-h-[120px] flex-col rounded-2xl border p-3 transition-all duration-300 ${
+                  isCurrentMonth
+                    ? 'bg-white/60 text-pink-900/80 hover:shadow-lg hover:shadow-pink-500/10'
+                    : 'bg-white/20 text-pink-900/40'
+                } ${isToday ? 'ring-2 ring-pink-300/70' : 'border-white/30'} ${
+                  !isCurrentMonth ? 'border-white/20' : ''
+                }`}
+              >
+                <div className="mb-2 flex items-center justify-between text-sm">
+                  <span className={`font-semibold ${isCurrentMonth ? 'text-pink-900/90' : ''}`}>{date.getDate()}</span>
+                  {items.length > 0 && (
+                    <span className="rounded-full bg-pink-500/20 px-2 py-0.5 text-[10px] font-semibold text-pink-700/80">
+                      {items.length} {items.length === 1 ? 'task' : 'tasks'}
+                    </span>
+                  )}
+                </div>
+                <div className="flex-1 space-y-2">
+                  {items.length === 0 ? (
+                    <div className="flex h-full items-center justify-center text-[11px] text-pink-900/30">
+                      {isCurrentMonth ? 'No tasks' : ''}
+                    </div>
+                  ) : (
+                    items.map((todo) => (
+                      <button
+                        key={todo.id}
+                        type="button"
+                        onClick={() => onToggleTodo(todo.id)}
+                        className={`w-full rounded-xl border px-2 py-1.5 text-left text-xs font-medium shadow-sm transition-all duration-200 hover:-translate-y-0.5 ${
+                          todo.completed
+                            ? 'border-green-200/80 bg-green-100/70 text-green-800 line-through'
+                            : 'border-white/40 bg-white/80 text-pink-900/90 hover:shadow-md'
+                        }`}
+                        title={todo.text}
+                      >
+                        <span className="block truncate">{todo.text}</span>
+                      </button>
+                    ))
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {undatedTodos.length > 0 && (
+        <div className="rounded-3xl border border-white/20 bg-white/30 p-5 backdrop-blur-lg">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-pink-900/60">No due date</h3>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {undatedTodos.map((todo) => (
+              <button
+                key={todo.id}
+                type="button"
+                onClick={() => onToggleTodo(todo.id)}
+                className={`rounded-full border px-3 py-1 text-sm shadow-sm transition-all duration-200 ${
+                  todo.completed
+                    ? 'border-green-200/80 bg-green-100/70 text-green-800 line-through'
+                    : 'border-white/30 bg-white/60 text-pink-900/80 hover:border-white/50 hover:bg-white/80'
+                }`}
+              >
+                {todo.text}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Calendar;

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -1,0 +1,144 @@
+import type { FormEventHandler } from 'react';
+import type { TodoItem } from '../types';
+
+interface TodoListProps {
+  todos: TodoItem[];
+  newTodo: string;
+  newDueDate: string;
+  deletingId: number | null;
+  onNewTodoChange: (value: string) => void;
+  onDueDateChange: (value: string) => void;
+  onAddTodo: FormEventHandler<HTMLFormElement>;
+  onToggleTodo: (id: number) => void;
+  onDeleteTodo: (id: number) => void;
+}
+
+const TodoList = ({
+  todos,
+  newTodo,
+  newDueDate,
+  deletingId,
+  onNewTodoChange,
+  onDueDateChange,
+  onAddTodo,
+  onToggleTodo,
+  onDeleteTodo,
+}: TodoListProps) => {
+  const completedCount = todos.filter((todo) => todo.completed).length;
+
+  const formatTodoDate = (todo: TodoItem) => {
+    const rawDate = todo.due_at ?? todo.created_at;
+    if (!rawDate) return 'No due date set';
+
+    const parsed = new Date(rawDate);
+    if (Number.isNaN(parsed.getTime())) return 'No due date set';
+
+    return parsed.toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  };
+
+  return (
+    <div className="animate-fadeIn">
+      <form onSubmit={onAddTodo} className="mb-8">
+        <div className="flex flex-col gap-3 md:flex-row">
+          <div className="flex flex-1 flex-col gap-3 sm:flex-row">
+            <input
+              type="text"
+              value={newTodo}
+              onChange={(e) => onNewTodoChange(e.target.value)}
+              placeholder="Add a new task..."
+              aria-label="Task description"
+              className="w-full rounded-xl border border-white/20 bg-white/10 p-3 text-pink-900/90 placeholder-pink-700/60 backdrop-blur-lg transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-white/30"
+            />
+            <input
+              type="date"
+              value={newDueDate}
+              onChange={(e) => onDueDateChange(e.target.value)}
+              aria-label="Choose a due date"
+              className="w-full rounded-xl border border-white/20 bg-white/10 p-3 text-pink-900/90 placeholder-pink-700/60 backdrop-blur-lg transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-white/30 sm:max-w-[200px]"
+            />
+          </div>
+          <button
+            type="submit"
+            className="rounded-xl border border-white/20 bg-pink-600/80 px-6 py-2 text-white shadow-lg backdrop-blur-lg transition-all duration-300 hover:border-white/30 hover:bg-pink-700/90 hover:shadow-[0_0_20px_rgba(236,72,153,0.4)] active:scale-95"
+          >
+            Add
+          </button>
+        </div>
+      </form>
+
+      {todos.length === 0 ? (
+        <div className="animate-fadeIn rounded-2xl border border-white/20 bg-white/30 p-6 text-center text-pink-900/70 backdrop-blur-lg">
+          No tasks yet — add something above to get started!
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {todos.map((todo) => (
+            <div
+              key={todo.id}
+              className={`flex items-start rounded-2xl border border-white/20 p-4 backdrop-blur-lg transition-all duration-300 ${
+                deletingId === todo.id ? 'animate-fadeOut' : 'animate-fadeIn'
+              } ${
+                todo.completed
+                  ? 'bg-green-100/40 text-green-900/90 hover:shadow-lg hover:shadow-green-500/10'
+                  : 'bg-white/40 text-pink-900/90 hover:bg-white/60 hover:shadow-lg hover:shadow-pink-500/10'
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={todo.completed}
+                onChange={() => onToggleTodo(todo.id)}
+                className="mt-1 h-5 w-5 rounded-full border-pink-200 text-pink-400 transition-transform duration-200 focus:ring-pink-300"
+                aria-label={`Mark ${todo.text} as ${todo.completed ? 'incomplete' : 'complete'}`}
+              />
+              <div className="ml-3 flex-1">
+                <p
+                  className={`font-medium transition-all duration-300 ${
+                    todo.completed ? 'line-through text-green-900/60 animate-completePulse' : ''
+                  }`}
+                >
+                  {todo.text}
+                </p>
+                <p className="mt-1 text-xs text-pink-900/70">
+                  {todo.due_at ? 'Due' : 'Added'} {formatTodoDate(todo)}
+                </p>
+              </div>
+              <button
+                onClick={() => onDeleteTodo(todo.id)}
+                className="rounded-lg p-1 text-pink-700/70 transition-colors duration-200 hover:bg-pink-100/50 hover:text-pink-900"
+                aria-label={`Delete ${todo.text}`}
+                type="button"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                  />
+                </svg>
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {todos.length > 0 && (
+        <div className="mt-6 text-center text-sm text-gray-500 animate-fadeUp">
+          {completedCount} of {todos.length} tasks completed
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TodoList;

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,3 +102,11 @@ export interface ContextModule {
     workflow_state: string;
     unlock_at: string;
 }
+
+export interface TodoItem {
+    id: number;
+    text: string;
+    due_at?: string | null;
+    created_at?: string;
+    completed: boolean;
+}


### PR DESCRIPTION
## Summary
- refactor `App.tsx` into a planner hub that manages Canvas data, user tasks, and a slider to toggle between list and calendar views
- introduce a dedicated `TodoList` component with a due-date field and glassmorphism styling consistent with the existing aesthetic
- add an animated monthly `Calendar` component with navigation, per-day task chips, and an undated task section backed by a shared `TodoItem` type

## Testing
- npm run build
- npm run lint *(fails: existing `@typescript-eslint/no-explicit-any` errors in proxyserver.ts and types.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e53f3acc8332bf17687dd85420ed