### PR TITLE
Persist planner tasks in SQLite and polish archives

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,37 @@
+-- Kota's Planner SQLite schema
+-- Stores active tasks from Canvas and manual entries, with archival history
+-- for completed and deleted tasks.
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS planner_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    external_id INTEGER,
+    origin TEXT NOT NULL CHECK (origin IN ('canvas', 'manual')),
+    title TEXT NOT NULL,
+    notes TEXT,
+    due_at TEXT,
+    scheduled_time TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    completed INTEGER NOT NULL DEFAULT 0,
+    archived_at TEXT,
+    archived_reason TEXT CHECK (archived_reason IN ('completed', 'deleted'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS planner_items_origin_external_unique
+    ON planner_items(origin, external_id);
+
+CREATE INDEX IF NOT EXISTS planner_items_archived_reason_idx
+    ON planner_items(archived_reason);
+
+CREATE TABLE IF NOT EXISTS planner_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    planner_item_id INTEGER NOT NULL,
+    event_type TEXT NOT NULL CHECK (event_type IN ('completed', 'deleted', 'restored')),
+    occurred_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    metadata TEXT DEFAULT '{}',
+    FOREIGN KEY (planner_item_id) REFERENCES planner_items(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS planner_events_item_idx
+    ON planner_events(planner_item_id, occurred_at DESC);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "weird-todo-list",
       "version": "0.0.0",
       "dependencies": {
+        "@types/better-sqlite3": "^7.6.13",
+        "better-sqlite3": "^12.2.0",
         "dotenv": "^17.2.2",
         "express": "^5.1.0",
         "framer-motion": "^12.23.12",
@@ -1587,6 +1589,15 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -1675,7 +1686,6 @@
       "version": "24.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.0.tgz",
       "integrity": "sha512-y1dMvuvJspJiPSDZUQ+WMBvF7dpnEqN4x9DDC9ie5Fs/HUZJA3wFp7EhHoVaKX/iI0cRoECV8X2jL8zi0xrHCg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.12.0"
@@ -2106,6 +2116,60 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.2.0.tgz",
+      "integrity": "sha512-eGbYq2CT+tos1fBwLQ/tkBt9J5M3JEHjku4hbvQUePCckkvVf14xWj+1m7dGoK81M/fOjFT7yM9UMeKT/+vFLQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
@@ -2148,6 +2212,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bytes": {
@@ -2395,6 +2483,30 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2415,7 +2527,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
       "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -2467,6 +2578,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -2771,6 +2891,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/express": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
@@ -2910,6 +3039,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3035,6 +3170,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3105,6 +3246,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -3229,6 +3376,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3270,6 +3437,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -3752,6 +3925,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3763,6 +3948,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -3804,6 +3998,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/motion-dom": {
       "version": "12.23.12",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
@@ -3844,6 +4044,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3858,6 +4064,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.77.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.77.0.tgz",
+      "integrity": "sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-domexception": {
@@ -4082,6 +4300,32 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4103,6 +4347,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -4191,6 +4445,30 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
@@ -4210,6 +4488,20 @@
       },
       "peerDependencies": {
         "react": "^19.1.1"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/require-directory": {
@@ -4370,7 +4662,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4530,6 +4821,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4547,6 +4883,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -4640,6 +4985,40 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tinyglobby": {
@@ -4741,6 +5120,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4810,7 +5201,6 @@
       "version": "7.12.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
       "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -4831,6 +5221,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "better-sqlite3": "^12.2.0",
     "dotenv": "^17.2.2",
     "express": "^5.1.0",
     "framer-motion": "^12.23.12",

--- a/proxyserver.ts
+++ b/proxyserver.ts
@@ -1,48 +1,209 @@
+import cors from "cors";
+import Database from "better-sqlite3";
+import dotenv from "dotenv";
 import express from "express";
 import fetch from "node-fetch";
-import dotenv from "dotenv";
-import cors from "cors";
+import fs from "node:fs";
+import path from "node:path";
 
-// load .env
 dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3001;
 const BASE_URL =
   process.env.CANVAS_API_URL || "https://nuevaschool.instructure.com/api/v1";
+const CANVAS_TOKEN = process.env.CANVAS_TOKEN;
 
 app.use(cors());
+app.use(express.json());
 
-if (!process.env.CANVAS_TOKEN) {
-  console.error("ERROR: CANVAS_TOKEN is not defined in .env file");
-  process.exit(1);
+const dbPath = path.resolve(process.cwd(), "db", "planner.sqlite3");
+const schemaPath = path.resolve(process.cwd(), "db", "schema.sql");
+
+const ensureDirectory = path.dirname(dbPath);
+if (!fs.existsSync(ensureDirectory)) {
+  fs.mkdirSync(ensureDirectory, { recursive: true });
 }
 
-/**
- * Helper to fetch all pages from Canvas API
- */
-async function fetchAllPages(url: string) {
-  let results: any[] = [];
+const db = new Database(dbPath);
+const schema = fs.readFileSync(schemaPath, "utf8");
+db.exec(schema);
+
+db.pragma("foreign_keys = ON");
+
+type ArchiveReason = "completed" | "deleted";
+type EventType = ArchiveReason | "restored";
+type TodoOrigin = "canvas" | "manual";
+
+interface PlannerRow {
+  id: number;
+  external_id: number | null;
+  origin: TodoOrigin;
+  title: string;
+  notes: string | null;
+  due_at: string | null;
+  scheduled_time: string | null;
+  created_at: string | null;
+  completed: 0 | 1;
+  archived_at: string | null;
+  archived_reason: ArchiveReason | null;
+}
+
+interface PlannerItem {
+  id: number;
+  external_id?: number | null;
+  text: string;
+  due_at: string | null;
+  created_at: string | null;
+  completed: boolean;
+  origin: TodoOrigin;
+  scheduled_time: string | null;
+  archived_at: string | null;
+  archived_reason?: ArchiveReason;
+}
+
+interface CanvasAssignment {
+  id: number;
+  name: string;
+  due_at?: string | null;
+  created_at?: string | null;
+  locked_for_user?: boolean;
+}
+
+interface CanvasTodo {
+  assignment?: CanvasAssignment;
+}
+
+const mapRowToTodo = (row: PlannerRow): PlannerItem => ({
+  id: row.id,
+  external_id: row.external_id ?? undefined,
+  text: row.title,
+  due_at: row.due_at ?? null,
+  created_at: row.created_at ?? null,
+  completed: Boolean(row.completed),
+  origin: row.origin,
+  scheduled_time: row.scheduled_time ?? null,
+  archived_at: row.archived_at ?? null,
+  archived_reason: row.archived_reason ?? undefined,
+});
+
+const getActiveTodos = (): PlannerItem[] =>
+  (db
+    .prepare(
+      `SELECT * FROM planner_items
+       WHERE archived_reason IS NULL
+       ORDER BY CASE WHEN due_at IS NULL THEN 1 ELSE 0 END,
+                COALESCE(due_at, created_at),
+                created_at`
+    )
+    .all() as PlannerRow[]).map(mapRowToTodo);
+
+const getArchivedByReason = (reason: ArchiveReason): PlannerItem[] =>
+  (db
+    .prepare(
+      `SELECT * FROM planner_items
+       WHERE archived_reason = ?
+       ORDER BY archived_at DESC`
+    )
+    .all(reason) as PlannerRow[]).map(mapRowToTodo);
+
+const getPlannerState = () => ({
+  active: getActiveTodos(),
+  archive: {
+    completed: getArchivedByReason("completed"),
+    deleted: getArchivedByReason("deleted"),
+  },
+});
+
+const selectItemByOrigin = db.prepare(
+  "SELECT * FROM planner_items WHERE origin = ? AND external_id = ?"
+);
+
+const insertManualItem = db.prepare(
+  `INSERT INTO planner_items (origin, title, due_at, scheduled_time, created_at, completed)
+   VALUES ('manual', @title, @due_at, @scheduled_time, @created_at, 0)`
+);
+
+const insertCanvasItem = db.prepare(
+  `INSERT INTO planner_items (origin, external_id, title, due_at, scheduled_time, created_at, completed)
+   VALUES ('canvas', @external_id, @title, @due_at, @scheduled_time, @created_at, 0)`
+);
+
+const updateCanvasItem = db.prepare(
+  `UPDATE planner_items
+   SET title = @title,
+       due_at = @due_at,
+       scheduled_time = @scheduled_time,
+       created_at = COALESCE(created_at, @created_at)
+   WHERE id = @id`
+);
+
+const archiveItemStatement = db.prepare(
+  `UPDATE planner_items
+   SET completed = CASE WHEN @reason = 'completed' THEN 1 ELSE completed END,
+       archived_at = @archived_at,
+       archived_reason = @reason
+   WHERE id = @id`
+);
+
+const restoreItemStatement = db.prepare(
+  `UPDATE planner_items
+   SET completed = 0,
+       archived_at = NULL,
+       archived_reason = NULL
+   WHERE id = ?`
+);
+
+const deleteItemStatement = db.prepare(
+  "DELETE FROM planner_items WHERE id = ?"
+);
+
+const insertEvent = db.prepare(
+  `INSERT INTO planner_events (planner_item_id, event_type, metadata)
+   VALUES (@planner_item_id, @event_type, @metadata)`
+);
+
+const recordEvent = (id: number, eventType: EventType, metadata: Record<string, unknown> = {}) => {
+  try {
+    insertEvent.run({
+      planner_item_id: id,
+      event_type: eventType,
+      metadata: JSON.stringify(metadata),
+    });
+  } catch (error) {
+    console.error("Failed to record planner event", error);
+  }
+};
+
+async function fetchAllPages(url: string): Promise<CanvasTodo[]> {
+  if (!CANVAS_TOKEN) {
+    throw new Error("Canvas token not configured");
+  }
+
+  const results: CanvasTodo[] = [];
   let nextUrl: string | null = url;
 
   while (nextUrl) {
-    const r = await fetch(nextUrl, {
+    const response = await fetch(nextUrl, {
       headers: {
-        Authorization: `Bearer ${process.env.CANVAS_TOKEN}`,
+        Authorization: `Bearer ${CANVAS_TOKEN}`,
         Accept: "application/json",
       },
     });
 
-    if (!r.ok) {
-      const errBody = await r.text();
-      throw new Error(`Canvas error ${r.status}: ${errBody}`);
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Canvas error ${response.status}: ${body}`);
     }
 
-    const data = await r.json();
-    results = results.concat(data);
+    const data = await response.json();
+    if (Array.isArray(data)) {
+      data.forEach((entry) => {
+        results.push(entry as CanvasTodo);
+      });
+    }
 
-    // parse Link header for rel="next"
-    const linkHeader = r.headers.get("link");
+    const linkHeader = response.headers.get("link");
     if (linkHeader) {
       const match = linkHeader.match(/<([^>]+)>;\s*rel="next"/);
       nextUrl = match ? match[1] : null;
@@ -54,40 +215,217 @@ async function fetchAllPages(url: string) {
   return results;
 }
 
+async function syncCanvasAssignments() {
+  if (!CANVAS_TOKEN) {
+    return;
+  }
+
+  const todos = await fetchAllPages(`${BASE_URL}/users/self/todo?per_page=100`);
+
+  for (const todo of todos) {
+    const assignment = todo?.assignment;
+    if (!assignment || assignment.locked_for_user) {
+      continue;
+    }
+
+    const externalId = assignment.id;
+
+    const dueAt = assignment.due_at || null;
+    const createdAt = assignment.created_at || new Date().toISOString();
+
+    const existing = selectItemByOrigin.get("canvas", externalId) as PlannerRow | undefined;
+
+    const derivedTime = (() => {
+      if (!dueAt) return null;
+      const parsed = new Date(dueAt);
+      if (Number.isNaN(parsed.getTime())) return null;
+      const hours = String(parsed.getHours()).padStart(2, "0");
+      const minutes = String(parsed.getMinutes()).padStart(2, "0");
+      return `${hours}:${minutes}`;
+    })();
+
+    if (!existing) {
+      insertCanvasItem.run({
+        external_id: externalId,
+        title: assignment.name,
+        due_at: dueAt,
+        scheduled_time: derivedTime,
+        created_at: createdAt,
+      });
+      continue;
+    }
+
+    if (existing.archived_reason) {
+      continue;
+    }
+
+    updateCanvasItem.run({
+      id: existing.id,
+      title: assignment.name,
+      due_at: dueAt,
+      scheduled_time: derivedTime,
+      created_at: createdAt,
+    });
+  }
+}
+
+app.get("/api/planner", async (req, res) => {
+  try {
+    if (req.query.sync === "true") {
+      try {
+        await syncCanvasAssignments();
+      } catch (error) {
+        console.error("Failed to sync Canvas assignments", error);
+      }
+    }
+
+    res.json(getPlannerState());
+  } catch (error) {
+    console.error("Failed to load planner state", error);
+    res.status(500).json({ error: "Failed to load planner state" });
+  }
+});
+
+app.post("/api/planner/manual", (req, res) => {
+  try {
+    const { text, due_at: dueAt, scheduled_time: scheduledTime } = req.body ?? {};
+
+    if (!text || typeof text !== "string") {
+      res.status(400).json({ error: "Manual tasks require text" });
+      return;
+    }
+
+    const createdAt = new Date().toISOString();
+
+    insertManualItem.run({
+      title: text.trim(),
+      due_at: dueAt || null,
+      scheduled_time: scheduledTime || null,
+      created_at: createdAt,
+    });
+
+    res.json(getPlannerState());
+  } catch (error) {
+    console.error("Failed to create manual task", error);
+    res.status(500).json({ error: "Failed to create manual task" });
+  }
+});
+
+app.post("/api/planner/:id/archive", (req, res) => {
+  try {
+    const id = Number.parseInt(req.params.id, 10);
+    const { reason } = req.body ?? {};
+
+    if (!id || (reason !== "completed" && reason !== "deleted")) {
+      res.status(400).json({ error: "Invalid archive request" });
+      return;
+    }
+
+    const archivedAt = new Date().toISOString();
+    const result = archiveItemStatement.run({
+      id,
+      reason,
+      archived_at: archivedAt,
+    });
+
+    if (result.changes === 0) {
+      res.status(404).json({ error: "Task not found" });
+      return;
+    }
+
+    recordEvent(id, reason, { archived_at: archivedAt });
+
+    res.json(getPlannerState());
+  } catch (error) {
+    console.error("Failed to archive task", error);
+    res.status(500).json({ error: "Failed to archive task" });
+  }
+});
+
+app.post("/api/planner/:id/restore", (req, res) => {
+  try {
+    const id = Number.parseInt(req.params.id, 10);
+    if (!id) {
+      res.status(400).json({ error: "Invalid restore request" });
+      return;
+    }
+
+    const result = restoreItemStatement.run(id);
+
+    if (result.changes === 0) {
+      res.status(404).json({ error: "Task not found" });
+      return;
+    }
+
+    recordEvent(id, "restored");
+
+    res.json(getPlannerState());
+  } catch (error) {
+    console.error("Failed to restore task", error);
+    res.status(500).json({ error: "Failed to restore task" });
+  }
+});
+
+app.delete("/api/planner/:id", (req, res) => {
+  try {
+    const id = Number.parseInt(req.params.id, 10);
+    if (!id) {
+      res.status(400).json({ error: "Invalid delete request" });
+      return;
+    }
+
+    const result = deleteItemStatement.run(id);
+
+    if (result.changes === 0) {
+      res.status(404).json({ error: "Task not found" });
+      return;
+    }
+
+    res.json(getPlannerState());
+  } catch (error) {
+    console.error("Failed to remove task", error);
+    res.status(500).json({ error: "Failed to remove task" });
+  }
+});
+
 app.get("/api/todos", async (_req, res) => {
   try {
-    const todos = await fetchAllPages(
-      `${BASE_URL}/users/self/todo?per_page=100`
-    );
+    if (!CANVAS_TOKEN) {
+      res.status(500).json({
+        error: "CANVAS_TOKEN not configured",
+      });
+      return;
+    }
 
-    // Filter out locked assignments
-    const filtered = todos.filter(todo => {
-      const asn = todo.assignment;
-      return !(asn && asn.locked_for_user);
+    const todos = await fetchAllPages(`${BASE_URL}/users/self/todo?per_page=100`);
+
+    const filtered = todos.filter((todo) => {
+      const assignment = todo.assignment;
+      return !(assignment && assignment.locked_for_user);
     });
 
     filtered.sort((a, b) => {
       const aDue = a.assignment?.due_at;
       const bDue = b.assignment?.due_at;
-    
+
       if (!aDue && !bDue) return 0;
       if (!aDue) return 1;
       if (!bDue) return -1;
-    
-      return new Date(aDue).getTime() - new Date(bDue).getTime(); // earliest → latest
+
+      return new Date(aDue).getTime() - new Date(bDue).getTime();
     });
-    
 
     res.json(filtered);
-  } catch (err: any) {
-    console.error("Proxy error:", err.message);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("Proxy error:", message);
     res.status(500).json({
       error: "Failed to fetch from Canvas",
-      detail: err.message,
+      detail: message,
     });
   }
 });
 
-app.listen(PORT, () =>
-  console.log(`Express proxy running on http://localhost:${PORT}`)
-);
+app.listen(PORT, () => {
+  console.log(`Planner API running on http://localhost:${PORT}`);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,157 +1,438 @@
-import { useState, useEffect } from 'react';
-import { pullTodos } from './GetCanvasTodo';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { CSSProperties, FormEvent } from 'react';
+import Calendar from './components/Calendar';
+import TodoList from './components/TodoList';
+import type { ArchiveReason, PlannerStatePayload, TodoItem } from './types';
 
-function App() {
-  const [todos, setTodos] = useState<any[]>([]);
+type ViewMode = 'list' | 'calendar';
+
+const DARK_MODE_STORAGE_KEY = 'kota-planner-dark-mode';
+
+const schedule = (callback: () => void, delay: number) => {
+  if (typeof window !== 'undefined') {
+    window.setTimeout(callback, delay);
+    return;
+  }
+
+  setTimeout(callback, delay);
+};
+
+const App = () => {
+  const [activeTodos, setActiveTodos] = useState<TodoItem[]>([]);
+  const [completedArchive, setCompletedArchive] = useState<TodoItem[]>([]);
+  const [deletedArchive, setDeletedArchive] = useState<TodoItem[]>([]);
   const [newTodo, setNewTodo] = useState('');
+  const [newDueDate, setNewDueDate] = useState('');
+  const [newDueTime, setNewDueTime] = useState('');
   const [deletingId, setDeletingId] = useState<number | null>(null);
+  const [completingId, setCompletingId] = useState<number | null>(null);
+  const [viewMode, setViewMode] = useState<ViewMode>('list');
+  const [isDarkMode, setIsDarkMode] = useState(false);
+  const [latestArchivedId, setLatestArchivedId] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
-  // Load Canvas assignments
+  const applyPlannerState = useCallback(
+    (state: PlannerStatePayload) => {
+      setActiveTodos(state.active ?? []);
+      setCompletedArchive(state.archive?.completed ?? []);
+      setDeletedArchive(state.archive?.deleted ?? []);
+    },
+    [],
+  );
+
+  const loadPlannerState = useCallback(
+    async (options?: { sync?: boolean }) => {
+      const query = options?.sync ? '?sync=true' : '';
+      const response = await fetch(`/api/planner${query}`);
+      if (!response.ok) {
+        throw new Error(`Planner request failed with status ${response.status}`);
+      }
+      const payload = (await response.json()) as PlannerStatePayload;
+      applyPlannerState(payload);
+    },
+    [applyPlannerState],
+  );
+
   useEffect(() => {
-    pullTodos()
-      .then((canvasTodos) => {
-        const mapped = canvasTodos.map((t: any) => ({
-          id: t.assignment.id,
-          text: t.assignment.name,
-          due_at: t.assignment.due_at,
-          completed: false,
-        }));
-        setTodos(mapped);
-      })
-      .catch((err: Error) => console.error(err));
-  }, []);
+    let cancelled = false;
 
-  // Add your own task
-  const addTodo = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!newTodo.trim()) return;
-
-    const todo = {
-      id: Date.now(),
-      text: newTodo,
-      completed: false,
-      created_at: new Date().toISOString(),
+    const hydrate = async () => {
+      try {
+        await loadPlannerState({ sync: true });
+      } catch (error) {
+        console.error('Failed to hydrate planner', error);
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
     };
 
-    setTodos([todo, ...todos]);
-    setNewTodo('');
+    hydrate();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [loadPlannerState]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    try {
+      const stored = window.localStorage.getItem(DARK_MODE_STORAGE_KEY);
+      if (stored !== null) {
+        setIsDarkMode(stored === 'true');
+      }
+    } catch (error) {
+      console.error('Failed to read dark mode preference', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    try {
+      window.localStorage.setItem(DARK_MODE_STORAGE_KEY, isDarkMode ? 'true' : 'false');
+    } catch (error) {
+      console.error('Failed to persist dark mode preference', error);
+    }
+  }, [isDarkMode]);
+
+  const sortedActiveTodos = useMemo(() => {
+    const merged = [...activeTodos];
+
+    return merged.sort((a, b) => {
+      const getTime = (todo: TodoItem) => {
+        if (todo.due_at) {
+          const parsed = new Date(todo.due_at);
+          if (!Number.isNaN(parsed.getTime())) return parsed.getTime();
+        }
+        if (todo.created_at) {
+          const created = new Date(todo.created_at);
+          if (!Number.isNaN(created.getTime())) return created.getTime();
+        }
+        return Number.MAX_SAFE_INTEGER;
+      };
+
+      return getTime(a) - getTime(b);
+    });
+  }, [activeTodos]);
+
+  const addTodo = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = newTodo.trim();
+    if (!trimmed) return;
+
+    const dueDate = newDueDate ? new Date(`${newDueDate}T${newDueTime || '12:00'}:00`) : null;
+    const dueAt =
+      dueDate && !Number.isNaN(dueDate.getTime()) ? dueDate.toISOString() : null;
+    const manualTime = newDueTime || null;
+
+    try {
+      const response = await fetch('/api/planner/manual', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          text: trimmed,
+          due_at: dueAt,
+          scheduled_time: manualTime,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Manual task creation failed with status ${response.status}`);
+      }
+
+      const payload = (await response.json()) as PlannerStatePayload;
+      applyPlannerState(payload);
+      setNewTodo('');
+      setNewDueDate('');
+      setNewDueTime('');
+    } catch (error) {
+      console.error('Failed to create manual task', error);
+    }
   };
 
-  const toggleTodo = (id: number) => {
-    setTodos(
-      todos.map((todo) =>
-        todo.id === id ? { ...todo, completed: !todo.completed } : todo
-      )
-    );
+  const archiveWithAnimation = async (id: number, reason: ArchiveReason) => {
+    const duration = reason === 'completed' ? 650 : 360;
+    if (reason === 'completed') {
+      setCompletingId(id);
+    } else {
+      setDeletingId(id);
+    }
+
+    try {
+      const response = await fetch(`/api/planner/${id}/archive`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ reason }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Archive request failed with status ${response.status}`);
+      }
+
+      const payload = (await response.json()) as PlannerStatePayload;
+
+      schedule(() => {
+        applyPlannerState(payload);
+        if (reason === 'completed') {
+          setCompletingId(null);
+        } else {
+          setDeletingId(null);
+        }
+      }, duration);
+
+      setLatestArchivedId(id);
+      schedule(() => {
+        setLatestArchivedId((current) => (current === id ? null : current));
+      }, 1600);
+    } catch (error) {
+      console.error('Failed to archive task', error);
+      if (reason === 'completed') {
+        setCompletingId(null);
+      } else {
+        setDeletingId(null);
+      }
+    }
+  };
+
+  const completeTodo = (id: number) => {
+    void archiveWithAnimation(id, 'completed');
   };
 
   const deleteTodo = (id: number) => {
-    setDeletingId(id);
-    setTimeout(() => {
-      setTodos(todos.filter((todo) => todo.id !== id));
-      setDeletingId(null);
-    }, 300);
+    void archiveWithAnimation(id, 'deleted');
   };
 
-  return (
-    <div className="min-h-screen w-full bg-[#fefcff] relative p-4 md:p-8 overflow-hidden">
-      <div
-        className="absolute inset-0 z-0 animate-gradientMove"
-        style={{
-          backgroundImage: `
-            radial-gradient(circle at 30% 70%, rgba(173, 216, 230, 0.35), transparent 60%),
-            radial-gradient(circle at 70% 30%, rgba(255, 182, 193, 0.4), transparent 60%)`,
-        }}
-      />
-      <div className="relative z-10 mx-auto max-w-2xl">
-        <h1 className="mb-8 text-4xl font-bold text-center text-transparent bg-clip-text bg-gradient-to-r from-pink-300 to-purple-300 drop-shadow-lg animate-fadeDown">
-          Kota's ToDo List
-        </h1>
+  const restoreTodo = async (todo: TodoItem) => {
+    try {
+      const response = await fetch(`/api/planner/${todo.id}/restore`, {
+        method: 'POST',
+      });
 
-        {/* Add Todo Form */}
-        <form onSubmit={addTodo} className="mb-8">
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={newTodo}
-              onChange={(e) => setNewTodo(e.target.value)}
-              placeholder="Add a new task..."
-              className="flex-1 p-3 rounded-xl border backdrop-blur-lg transition-all duration-300 border-white/20 bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30 text-pink-900/90 placeholder-pink-700/60"
-            />
-            <button
-              type="submit"
-              className="px-6 py-2 bg-pink-600/80 hover:bg-pink-700/90 text-white rounded-xl backdrop-blur-lg border border-white/20 hover:border-white/30 transition-all duration-300 shadow-lg hover:shadow-[0_0_20px_rgba(236,72,153,0.4)] active:scale-95"
+      if (!response.ok) {
+        throw new Error(`Restore request failed with status ${response.status}`);
+      }
+
+      const payload = (await response.json()) as PlannerStatePayload;
+      applyPlannerState(payload);
+      setLatestArchivedId((current) => (current === todo.id ? null : current));
+    } catch (error) {
+      console.error('Failed to restore task', error);
+    }
+  };
+
+  const permanentlyDeleteTodo = async (todo: TodoItem) => {
+    const confirmed =
+      typeof window === 'undefined'
+        ? true
+        : window.confirm(`Delete "${todo.text}" forever? This cannot be undone.`);
+    if (!confirmed) return;
+
+    try {
+      const response = await fetch(`/api/planner/${todo.id}`, {
+        method: 'DELETE',
+      });
+
+      if (!response.ok) {
+        throw new Error(`Delete request failed with status ${response.status}`);
+      }
+
+      const payload = (await response.json()) as PlannerStatePayload;
+      applyPlannerState(payload);
+      setLatestArchivedId((current) => (current === todo.id ? null : current));
+    } catch (error) {
+      console.error('Failed to remove task permanently', error);
+    }
+  };
+
+  const toggleView = () => {
+    setViewMode((prev) => (prev === 'list' ? 'calendar' : 'list'));
+  };
+
+  const toggleDarkMode = () => {
+    setIsDarkMode((prev) => !prev);
+  };
+
+  const thumbGradient = isDarkMode
+    ? 'bg-gradient-to-r from-purple-500/80 to-indigo-500/80'
+    : 'bg-gradient-to-r from-pink-400/80 to-purple-400/80';
+
+  const trackClasses = isDarkMode
+    ? 'border-white/10 bg-white/10 text-indigo-100'
+    : 'border-white/30 bg-white/20 text-pink-900/70';
+
+  const listLabelClass = viewMode === 'list' ? 'text-white' : isDarkMode ? 'text-indigo-100/70' : 'text-pink-900/60';
+  const calendarLabelClass = viewMode === 'calendar' ? 'text-white' : isDarkMode ? 'text-indigo-100/70' : 'text-pink-900/60';
+
+  const sliderKnobClasses = `absolute inset-y-1 left-1 w-[calc(50%-0.5rem)] rounded-full shadow-lg transition-[transform,box-shadow] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] ${thumbGradient} transform-gpu ${
+    viewMode === 'calendar' ? 'translate-x-[calc(100%+0.5rem)]' : 'translate-x-0'
+  }`;
+
+  const contentRailTransform: CSSProperties = {
+    transform: viewMode === 'list' ? 'translateX(0%)' : 'translateX(-50%)',
+  };
+
+  const backgroundStyle: CSSProperties = isDarkMode
+    ? {
+        backgroundImage: `
+          radial-gradient(circle at 25% 65%, rgba(88, 28, 135, 0.55), transparent 58%),
+          radial-gradient(circle at 70% 30%, rgba(37, 99, 235, 0.35), transparent 65%)`,
+      }
+    : {
+        backgroundImage: `
+          radial-gradient(circle at 30% 70%, rgba(173, 216, 230, 0.35), transparent 60%),
+          radial-gradient(circle at 70% 30%, rgba(255, 182, 193, 0.4), transparent 60%)`,
+      };
+
+  return (
+    <div
+      className={`relative min-h-screen w-full overflow-hidden ${
+        isDarkMode ? 'bg-[#0b0314] text-indigo-50' : 'bg-[#fefcff] text-pink-900/80'
+      } p-4 md:p-8`}
+      aria-busy={isLoading}
+    >
+      <div className="animate-gradientMove absolute inset-0 z-0" style={backgroundStyle} />
+
+      <div className="relative z-10 mx-auto flex w-full max-w-5xl flex-col items-stretch">
+        <header className="mb-8 flex flex-col gap-6 text-center md:flex-row md:items-center md:justify-between md:text-left">
+          <div>
+            <h1
+              className={`mb-3 text-4xl font-bold text-transparent bg-clip-text drop-shadow-lg animate-fadeDown ${
+                isDarkMode ? 'bg-gradient-to-r from-purple-200 via-violet-200 to-indigo-200' : 'bg-gradient-to-r from-pink-300 to-purple-300'
+              }`}
             >
-              Add
+              Kota&apos;s Planner
+            </h1>
+            <p
+              className={`max-w-xl text-sm ${
+                isDarkMode ? 'text-indigo-100/70' : 'text-pink-900/70'
+              }`}
+            >
+              Toggle between a focused task list and a dreamy calendar overview to keep everything on track — now with
+              day, week, and month focus modes.
+            </p>
+          </div>
+
+          <div className="flex justify-center gap-3 md:justify-end">
+            <button
+              type="button"
+              onClick={toggleDarkMode}
+              className={`group flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-semibold shadow-md backdrop-blur ${
+                isDarkMode
+                  ? 'border-white/15 bg-white/10 text-indigo-100 hover:bg-white/20'
+                  : 'border-white/40 bg-white/60 text-pink-900/70 hover:bg-white/80'
+              }`}
+              aria-pressed={isDarkMode}
+              aria-label={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+            >
+              {isDarkMode ? (
+                <>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    className="h-4 w-4"
+                  >
+                    <path d="M21 12.79A9 9 0 0111.21 3a7 7 0 1010 9.79z" />
+                  </svg>
+                  <span>Dark</span>
+                </>
+              ) : (
+                <>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={1.5}
+                    stroke="currentColor"
+                    className="h-4 w-4"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z"
+                    />
+                  </svg>
+                  <span>Light</span>
+                </>
+              )}
             </button>
           </div>
-        </form>
+        </header>
 
-        {/* Todo List */}
-        <div className="space-y-3">
-          {todos.map((todo) => (
-            <div
-              key={todo.id}
-              className={`p-4 rounded-2xl backdrop-blur-lg transition-all duration-300 flex items-start border border-white/20
-                ${deletingId === todo.id ? 'animate-fadeOut' : 'animate-fadeIn'}
-                ${todo.completed
-                  ? 'bg-green-100/30 hover:shadow-lg hover:shadow-green-500/10 text-green-900/90'
-                  : 'bg-white/30 hover:bg-white/40 hover:shadow-lg hover:shadow-pink-500/10 text-pink-900/90'}
-              `}
-            >
-              <input
-                type="checkbox"
-                checked={todo.completed}
-                onChange={() => toggleTodo(todo.id)}
-                className="mt-1 w-5 h-5 text-pink-400 rounded-full border-pink-200 transition-transform duration-200 focus:ring-pink-300"
-              />
-              <div className="flex-1 ml-3">
-                <p
-                  className={`transition-all duration-300 ${
-                    todo.completed
-                      ? 'line-through text-green-900/60 animate-completePulse'
-                      : ''
-                  }`}
-                >
-                  {todo.text}
-                </p>
-                <p className="mt-1 text-xs text-pink-900/70">
-                  {new Date(todo.due_at || todo.created_at).toLocaleDateString()}
-                </p>
-              </div>
-              <button
-                onClick={() => deleteTodo(todo.id)}
-                className="p-1 rounded-lg transition-colors duration-200 text-pink-700/70 hover:text-pink-900 hover:bg-pink-100/50"
-                aria-label="Delete todo"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="w-5 h-5"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                  />
-                </svg>
-              </button>
-            </div>
-          ))}
+        <div className="mb-8 flex justify-center">
+          <button
+            type="button"
+            onClick={toggleView}
+            aria-pressed={viewMode === 'calendar'}
+            className={`relative flex w-full max-w-xs items-center justify-between rounded-full border p-1.5 text-sm font-semibold shadow-inner backdrop-blur ${trackClasses}`}
+          >
+            <span className={sliderKnobClasses} />
+            <span className={`relative z-10 flex-1 text-center ${listLabelClass}`}>List</span>
+            <span className={`relative z-10 flex-1 text-center ${calendarLabelClass}`}>Calendar</span>
+          </button>
         </div>
 
-        {/* Stats */}
-        {todos.length > 0 && (
-          <div className="mt-6 text-sm text-center text-gray-500 animate-fadeUp">
-            {todos.filter((t) => t.completed).length} of {todos.length} tasks completed
+        <div className="relative w-full overflow-hidden rounded-[2rem] border border-white/10 bg-white/10 p-1 backdrop-blur-lg">
+          <div
+            className="flex w-[200%] transform-gpu transition-transform duration-[650ms] ease-[cubic-bezier(0.22,1,0.36,1)]"
+            style={contentRailTransform}
+          >
+            <div
+              className={`w-1/2 flex-shrink-0 p-4 sm:p-6 transform-gpu transition-all duration-500 ease-out ${
+                viewMode === 'list'
+                  ? 'pointer-events-auto opacity-100 translate-y-0 scale-100'
+                  : 'pointer-events-none opacity-0 -translate-y-6 scale-95'
+              }`}
+            >
+              <TodoList
+                todos={sortedActiveTodos}
+                completedArchive={completedArchive}
+                deletedArchive={deletedArchive}
+                newTodo={newTodo}
+                newDueDate={newDueDate}
+                newDueTime={newDueTime}
+                deletingId={deletingId}
+                completingId={completingId}
+                isDarkMode={isDarkMode}
+                latestArchivedId={latestArchivedId}
+                isLoading={isLoading}
+                onNewTodoChange={setNewTodo}
+                onDueDateChange={setNewDueDate}
+                onDueTimeChange={setNewDueTime}
+                onAddTodo={addTodo}
+                onCompleteTodo={completeTodo}
+                onDeleteTodo={deleteTodo}
+                onRestoreTodo={restoreTodo}
+                onPermanentDelete={permanentlyDeleteTodo}
+              />
+            </div>
+            <div
+              className={`w-1/2 flex-shrink-0 p-4 sm:p-6 transform-gpu transition-all duration-500 ease-out ${
+                viewMode === 'calendar'
+                  ? 'pointer-events-auto opacity-100 translate-y-0 scale-100'
+                  : 'pointer-events-none opacity-0 translate-y-6 scale-95'
+              }`}
+            >
+              <Calendar todos={sortedActiveTodos} onCompleteTodo={completeTodo} isDarkMode={isDarkMode} />
+            </div>
           </div>
-        )}
+        </div>
+
+        <div className="mt-6 text-center text-xs font-semibold uppercase tracking-[0.3em] text-white/60">
+          {sortedActiveTodos.length === 0
+            ? 'All clear — enjoy the calm!'
+            : `${completedArchive.length} wins logged • ${completedArchive.length + deletedArchive.length} archived`}
+        </div>
       </div>
     </div>
   );
-}
+};
 
 export default App;

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,0 +1,561 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { TodoItem } from '../types';
+
+interface CalendarProps {
+  todos: TodoItem[];
+  onCompleteTodo: (id: number) => void;
+  isDarkMode: boolean;
+}
+
+type CalendarView = 'day' | 'week' | 'month';
+
+const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+const toDateKey = (date: Date) => {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const startOfMonth = (date: Date) => new Date(date.getFullYear(), date.getMonth(), 1);
+
+const startOfWeek = (date: Date) => {
+  const result = new Date(date);
+  const diff = result.getDay();
+  result.setDate(result.getDate() - diff);
+  return result;
+};
+
+const sameDay = (a: Date, b: Date) =>
+  a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+
+const getTodoDueDate = (todo: TodoItem): Date | null => {
+  if (!todo.due_at) return null;
+  const parsed = new Date(todo.due_at);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed;
+};
+
+const formatTimeForTodo = (todo: TodoItem) => {
+  if (todo.scheduled_time) {
+    const [hoursStr, minutesStr] = todo.scheduled_time.split(':');
+    const hours = Number.parseInt(hoursStr ?? '', 10);
+    const minutes = Number.parseInt(minutesStr ?? '', 10);
+    if (!Number.isNaN(hours) && !Number.isNaN(minutes)) {
+      const display = new Date();
+      display.setHours(hours, minutes, 0, 0);
+      return display.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+    }
+  }
+
+  const due = getTodoDueDate(todo);
+  if (!due) return null;
+  return due.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+};
+
+const Calendar = ({ todos, onCompleteTodo, isDarkMode }: CalendarProps) => {
+  const [currentMonth, setCurrentMonth] = useState(() => startOfMonth(new Date()));
+  const [selectedDate, setSelectedDate] = useState(() => new Date());
+  const [viewScope, setViewScope] = useState<CalendarView>('month');
+
+  useEffect(() => {
+    if (viewScope === 'month') {
+      setCurrentMonth(startOfMonth(selectedDate));
+    }
+  }, [selectedDate, viewScope]);
+
+  const calendarDays = useMemo(() => {
+    const firstDay = startOfMonth(currentMonth);
+    const lastDay = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0);
+
+    const leadingDays = firstDay.getDay();
+    const trailingDays = 6 - lastDay.getDay();
+    const totalCells = leadingDays + lastDay.getDate() + trailingDays;
+
+    const startDate = new Date(firstDay);
+    startDate.setDate(firstDay.getDate() - leadingDays);
+
+    const days: Date[] = [];
+    for (let i = 0; i < totalCells; i += 1) {
+      const day = new Date(startDate);
+      day.setDate(startDate.getDate() + i);
+      days.push(day);
+    }
+
+    return days;
+  }, [currentMonth]);
+
+  const todosByDay = useMemo(() => {
+    const grouped: Record<string, TodoItem[]> = {};
+
+    todos.forEach((todo) => {
+      const date = getTodoDueDate(todo);
+      if (!date) return;
+      const key = toDateKey(date);
+      grouped[key] = [...(grouped[key] ?? []), todo];
+    });
+
+    Object.keys(grouped).forEach((key) => {
+      grouped[key].sort((a, b) => {
+        const dateA = getTodoDueDate(a)?.getTime() ?? 0;
+        const dateB = getTodoDueDate(b)?.getTime() ?? 0;
+        if (dateA !== dateB) return dateA - dateB;
+        if (a.scheduled_time && b.scheduled_time && a.scheduled_time !== b.scheduled_time) {
+          return a.scheduled_time.localeCompare(b.scheduled_time);
+        }
+        return a.text.localeCompare(b.text);
+      });
+    });
+
+    return grouped;
+  }, [todos]);
+
+  const undatedTodos = useMemo(
+    () =>
+      todos.filter(
+        (todo) => !todo.due_at || Number.isNaN(new Date(todo.due_at).getTime()),
+      ),
+    [todos],
+  );
+
+  const today = new Date();
+  const monthLabel = currentMonth.toLocaleDateString(undefined, {
+    month: 'long',
+    year: 'numeric',
+  });
+
+  const weekDays = useMemo(() => {
+    const start = startOfWeek(selectedDate);
+    return Array.from({ length: 7 }, (_, index) => {
+      const day = new Date(start);
+      day.setDate(start.getDate() + index);
+      return day;
+    });
+  }, [selectedDate]);
+
+  const weekLabel = `${weekDays[0].toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  })} – ${weekDays[6].toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}`;
+
+  const dayLabel = selectedDate.toLocaleDateString(undefined, {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  const goToPrevious = () => {
+    if (viewScope === 'month') {
+      setCurrentMonth((prev) => new Date(prev.getFullYear(), prev.getMonth() - 1, 1));
+      setSelectedDate((prev) => {
+        const next = new Date(prev);
+        next.setMonth(prev.getMonth() - 1);
+        return next;
+      });
+      return;
+    }
+
+    setSelectedDate((prev) => {
+      const next = new Date(prev);
+      next.setDate(prev.getDate() - (viewScope === 'week' ? 7 : 1));
+      setCurrentMonth(startOfMonth(next));
+      return next;
+    });
+  };
+
+  const goToNext = () => {
+    if (viewScope === 'month') {
+      setCurrentMonth((prev) => new Date(prev.getFullYear(), prev.getMonth() + 1, 1));
+      setSelectedDate((prev) => {
+        const next = new Date(prev);
+        next.setMonth(prev.getMonth() + 1);
+        return next;
+      });
+      return;
+    }
+
+    setSelectedDate((prev) => {
+      const next = new Date(prev);
+      next.setDate(prev.getDate() + (viewScope === 'week' ? 7 : 1));
+      setCurrentMonth(startOfMonth(next));
+      return next;
+    });
+  };
+
+  const goToToday = () => {
+    const now = new Date();
+    setSelectedDate(now);
+    setCurrentMonth(startOfMonth(now));
+  };
+
+  const dayTasks = useMemo(() => {
+    const key = toDateKey(selectedDate);
+    return todosByDay[key] ?? [];
+  }, [selectedDate, todosByDay]);
+
+  const viewBadge = viewScope === 'month' ? monthLabel : viewScope === 'week' ? `Week of ${weekLabel}` : dayLabel;
+
+  const badgeClasses = isDarkMode
+    ? 'bg-gradient-to-r from-indigo-500/30 to-purple-500/30 text-indigo-100'
+    : 'bg-gradient-to-r from-pink-300/40 to-purple-300/40 text-pink-900/80';
+
+  const segmentButtonClasses = (scope: CalendarView) => {
+    const isActive = viewScope === scope;
+    if (isDarkMode) {
+      return `flex-1 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide transition ${
+        isActive
+          ? 'bg-indigo-500/80 text-white shadow-lg'
+          : 'text-indigo-100/60 hover:bg-indigo-500/20'
+      }`;
+    }
+
+    return `flex-1 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide transition ${
+      isActive
+        ? 'bg-pink-500/80 text-white shadow-lg'
+        : 'text-pink-900/60 hover:bg-pink-500/20'
+    }`;
+  };
+
+  return (
+    <div className="animate-fadeIn space-y-6">
+      <div
+        className={`rounded-3xl border p-6 shadow-xl backdrop-blur-xl transition-colors ${
+          isDarkMode ? 'border-white/10 bg-white/5 text-indigo-50' : 'border-white/30 bg-white/60 text-pink-900/80'
+        }`}
+      >
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className={`text-xs uppercase tracking-[0.4em] ${isDarkMode ? 'text-indigo-200/60' : 'text-pink-900/60'}`}>
+              Planner overview
+            </p>
+            <h2 className={`mt-2 text-3xl font-semibold text-transparent bg-clip-text ${
+              isDarkMode ? 'bg-gradient-to-r from-purple-200 via-indigo-200 to-slate-100' : 'bg-gradient-to-r from-pink-400 to-purple-400'
+            }`}
+            >
+              {viewBadge}
+            </h2>
+          </div>
+          <div className="flex flex-col gap-3 sm:items-end">
+            <div className={`flex items-center gap-2 rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-wide ${badgeClasses}`}>
+              Focus: {viewScope.toUpperCase()}
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={goToPrevious}
+                className={`rounded-full border p-2 transition ${
+                  isDarkMode
+                    ? 'border-white/10 bg-white/10 text-indigo-100 hover:bg-white/20'
+                    : 'border-white/30 bg-white/40 text-pink-700/80 hover:bg-white/70'
+                }`}
+                aria-label="Previous"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                  <path
+                    fillRule="evenodd"
+                    d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 11-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </button>
+              <button
+                type="button"
+                onClick={goToToday}
+                className={`rounded-full border px-4 py-2 text-xs font-semibold shadow-md transition ${
+                  isDarkMode
+                    ? 'border-white/15 bg-indigo-500/40 text-white hover:bg-indigo-500/60'
+                    : 'border-white/40 bg-gradient-to-r from-pink-300/70 to-purple-300/70 text-white hover:shadow-lg hover:shadow-pink-500/20'
+                }`}
+              >
+                Today
+              </button>
+              <button
+                type="button"
+                onClick={goToNext}
+                className={`rounded-full border p-2 transition ${
+                  isDarkMode
+                    ? 'border-white/10 bg-white/10 text-indigo-100 hover:bg-white/20'
+                    : 'border-white/30 bg-white/40 text-pink-700/80 hover:bg-white/70'
+                }`}
+                aria-label="Next"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                  <path
+                    fillRule="evenodd"
+                    d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </button>
+            </div>
+            <div className={`flex items-center gap-2 rounded-full border px-1 py-1 ${
+              isDarkMode ? 'border-white/10 bg-white/5' : 'border-white/40 bg-white/60'
+            }`}
+            >
+              {(['day', 'week', 'month'] as CalendarView[]).map((scope) => (
+                <button
+                  key={scope}
+                  type="button"
+                  onClick={() => setViewScope(scope)}
+                  className={segmentButtonClasses(scope)}
+                  aria-pressed={viewScope === scope}
+                >
+                  {scope.charAt(0).toUpperCase() + scope.slice(1)}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {viewScope === 'month' && (
+          <div className="mt-6 space-y-4">
+            <div
+              className={`grid grid-cols-7 gap-2 text-center text-xs font-semibold uppercase tracking-wide ${
+                isDarkMode ? 'text-indigo-100/70' : 'text-pink-600/80'
+              }`}
+            >
+              {dayNames.map((day) => (
+                <div key={day} className={`rounded-xl py-2 backdrop-blur ${isDarkMode ? 'bg-white/10' : 'bg-white/40'}`}>
+                  {day}
+                </div>
+              ))}
+            </div>
+
+            <div className="grid grid-cols-7 gap-2">
+              {calendarDays.map((date) => {
+                const key = toDateKey(date);
+                const items = todosByDay[key] ?? [];
+                const isCurrentMonth =
+                  date.getMonth() === currentMonth.getMonth() && date.getFullYear() === currentMonth.getFullYear();
+                const isToday = sameDay(date, today);
+                const isSelected = sameDay(date, selectedDate);
+
+                return (
+                  <button
+                    type="button"
+                    key={key}
+                    onClick={() => setSelectedDate(date)}
+                    className={`flex min-h-[120px] flex-col rounded-2xl border p-3 text-left transition-all duration-300 ${
+                      isCurrentMonth
+                        ? isDarkMode
+                          ? 'border-white/10 bg-white/10 text-indigo-100 hover:bg-white/20'
+                          : 'border-white/30 bg-white/70 text-pink-900/80 hover:shadow-lg hover:shadow-pink-500/10'
+                        : isDarkMode
+                        ? 'border-white/5 bg-white/5 text-indigo-200/40'
+                        : 'border-white/15 bg-white/30 text-pink-900/40'
+                    } ${isToday ? (isDarkMode ? 'ring-2 ring-indigo-400/70' : 'ring-2 ring-pink-300/70') : ''} ${
+                      isSelected ? (isDarkMode ? 'outline outline-1 outline-indigo-200/60' : 'outline outline-1 outline-pink-400/60') : ''
+                    }`}
+                  >
+                    <div className="mb-2 flex items-center justify-between text-sm">
+                      <span className={`font-semibold ${isCurrentMonth ? '' : 'opacity-60'}`}>{date.getDate()}</span>
+                      {items.length > 0 && (
+                        <span
+                          className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${
+                            isDarkMode ? 'bg-indigo-500/30 text-indigo-100' : 'bg-pink-500/20 text-pink-700/80'
+                          }`}
+                        >
+                          {items.length} {items.length === 1 ? 'task' : 'tasks'}
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex-1 space-y-1.5">
+                      {items.length === 0 ? (
+                        <div className={`flex h-full items-center justify-center text-[11px] ${
+                          isDarkMode ? 'text-indigo-100/30' : 'text-pink-900/30'
+                        }`}
+                        >
+                          {isCurrentMonth ? 'No tasks' : ''}
+                        </div>
+                      ) : (
+                        items.slice(0, 3).map((todo) => (
+                          <div
+                            key={todo.id}
+                            className={`w-full truncate rounded-xl border px-2 py-1 text-left text-xs font-medium shadow-sm ${
+                              isDarkMode
+                                ? 'border-white/10 bg-white/10 text-indigo-100'
+                                : 'border-white/40 bg-white/80 text-pink-900/90'
+                            } ${todo.completed ? 'line-through opacity-70' : ''}`}
+                          >
+                            {todo.text}
+                          </div>
+                        ))
+                      )}
+                    </div>
+                    {items.length > 3 && (
+                      <span className={`mt-2 text-[10px] italic ${isDarkMode ? 'text-indigo-200/60' : 'text-pink-900/50'}`}>
+                        +{items.length - 3} more
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {viewScope === 'week' && (
+          <div className="mt-6 space-y-4">
+            <p className={`text-xs uppercase tracking-[0.4em] ${isDarkMode ? 'text-indigo-200/60' : 'text-pink-900/60'}`}>
+              {weekLabel}
+            </p>
+            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+              {weekDays.map((date) => {
+                const key = toDateKey(date);
+                const items = todosByDay[key] ?? [];
+                const isSelected = sameDay(date, selectedDate);
+
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setSelectedDate(date)}
+                    className={`flex h-full flex-col justify-between rounded-2xl border p-4 text-left transition ${
+                      isDarkMode
+                        ? 'border-white/10 bg-white/10 text-indigo-100 hover:bg-white/20'
+                        : 'border-white/20 bg-white/70 text-pink-900/80 hover:shadow-lg hover:shadow-pink-500/10'
+                    } ${isSelected ? (isDarkMode ? 'ring-2 ring-indigo-400/70' : 'ring-2 ring-pink-300/70') : ''}`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="text-xs uppercase tracking-[0.3em]">{dayNames[date.getDay()]}</p>
+                        <p className="text-lg font-semibold">{date.getDate()}</p>
+                      </div>
+                      {items.length > 0 && (
+                        <span className={`rounded-full px-2 py-0.5 text-[11px] font-semibold ${
+                          isDarkMode ? 'bg-indigo-500/30 text-indigo-100' : 'bg-pink-500/20 text-pink-700/80'
+                        }`}
+                        >
+                          {items.length} {items.length === 1 ? 'task' : 'tasks'}
+                        </span>
+                      )}
+                    </div>
+                    <div className="mt-4 space-y-2">
+                      {items.length === 0 ? (
+                        <p className={`text-sm italic ${isDarkMode ? 'text-indigo-200/60' : 'text-pink-900/60'}`}>
+                          Empty space – perfect for a break.
+                        </p>
+                      ) : (
+                        items.map((todo) => (
+                          <button
+                            key={todo.id}
+                            type="button"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              onCompleteTodo(todo.id);
+                            }}
+                            className={`flex w-full items-center justify-between rounded-xl border px-3 py-2 text-left text-xs font-medium transition ${
+                              isDarkMode
+                                ? 'border-white/10 bg-white/10 text-indigo-100 hover:bg-indigo-500/20'
+                                : 'border-white/30 bg-white/80 text-pink-900/90 hover:bg-white'
+                            } ${todo.completed ? 'line-through opacity-70' : ''}`}
+                          >
+                            <span className="truncate">{todo.text}</span>
+                            {formatTimeForTodo(todo) && (
+                              <span className={`ml-2 whitespace-nowrap text-[10px] uppercase ${
+                                isDarkMode ? 'text-indigo-200/80' : 'text-pink-900/60'
+                              }`}
+                              >
+                                {formatTimeForTodo(todo)}
+                              </span>
+                            )}
+                          </button>
+                        ))
+                      )}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {viewScope === 'day' && (
+          <div className="mt-6 space-y-4">
+            <p className={`text-xs uppercase tracking-[0.4em] ${isDarkMode ? 'text-indigo-200/60' : 'text-pink-900/60'}`}>
+              {dayLabel}
+            </p>
+            <div className={`rounded-2xl border p-5 ${
+              isDarkMode ? 'border-white/10 bg-white/10 text-indigo-100' : 'border-white/20 bg-white/70 text-pink-900/80'
+            }`}
+            >
+              {dayTasks.length === 0 ? (
+                <p className={`text-sm italic ${isDarkMode ? 'text-indigo-200/60' : 'text-pink-900/60'}`}>
+                  No scheduled tasks — take a deep breath.
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  {dayTasks.map((todo) => (
+                    <button
+                      key={todo.id}
+                      type="button"
+                      onClick={() => onCompleteTodo(todo.id)}
+                      className={`w-full rounded-2xl border px-4 py-3 text-left text-sm transition ${
+                        isDarkMode
+                          ? 'border-white/10 bg-white/10 text-indigo-100 hover:bg-indigo-500/20'
+                          : 'border-white/30 bg-white/80 text-pink-900/90 hover:bg-white'
+                      } ${todo.completed ? 'line-through opacity-70' : ''}`}
+                    >
+                      <div className="flex items-start justify-between gap-4">
+                        <div>
+                          <p className="font-semibold">{todo.text}</p>
+                          <p className={`mt-1 text-xs ${isDarkMode ? 'text-indigo-200/70' : 'text-pink-900/60'}`}>
+                            {todo.due_at
+                              ? new Date(todo.due_at).toLocaleString(undefined, {
+                                  hour: 'numeric',
+                                  minute: '2-digit',
+                                  month: 'short',
+                                  day: 'numeric',
+                                })
+                              : 'No due date'}
+                          </p>
+                        </div>
+                        {formatTimeForTodo(todo) && (
+                          <span className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${
+                            isDarkMode ? 'bg-indigo-500/30 text-indigo-100' : 'bg-pink-500/20 text-pink-700/80'
+                          }`}
+                          >
+                            {formatTimeForTodo(todo)}
+                          </span>
+                        )}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {undatedTodos.length > 0 && (
+        <div
+          className={`rounded-3xl border p-5 backdrop-blur-lg ${
+            isDarkMode ? 'border-white/10 bg-white/10 text-indigo-100' : 'border-white/20 bg-white/40 text-pink-900/80'
+          }`}
+        >
+          <h3 className="text-sm font-semibold uppercase tracking-wide">No due date</h3>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {undatedTodos.map((todo) => (
+              <button
+                key={todo.id}
+                type="button"
+                onClick={() => onCompleteTodo(todo.id)}
+                className={`rounded-full border px-3 py-1 text-sm shadow-sm transition-all duration-200 ${
+                  isDarkMode
+                    ? 'border-white/10 bg-white/10 text-indigo-100 hover:bg-indigo-500/20'
+                    : 'border-white/30 bg-white/60 text-pink-900/80 hover:border-white/50 hover:bg-white/80'
+                } ${todo.completed ? 'line-through opacity-70' : ''}`}
+              >
+                {todo.text}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Calendar;

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -1,0 +1,409 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { FormEventHandler } from 'react';
+import type { ArchiveReason, TodoItem } from '../types';
+
+interface TodoListProps {
+  todos: TodoItem[];
+  completedArchive: TodoItem[];
+  deletedArchive: TodoItem[];
+  newTodo: string;
+  newDueDate: string;
+  newDueTime: string;
+  deletingId: number | null;
+  completingId: number | null;
+  isDarkMode: boolean;
+  latestArchivedId: number | null;
+  isLoading: boolean;
+  onNewTodoChange: (value: string) => void;
+  onDueDateChange: (value: string) => void;
+  onDueTimeChange: (value: string) => void;
+  onAddTodo: FormEventHandler<HTMLFormElement>;
+  onCompleteTodo: (id: number) => void;
+  onDeleteTodo: (id: number) => void;
+  onRestoreTodo: (todo: TodoItem) => void;
+  onPermanentDelete: (todo: TodoItem) => void;
+}
+
+const formatDate = (value?: string | null) => {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+};
+
+const formatTime = (value?: string | null) => {
+  if (!value) return null;
+  const [hoursStr, minutesStr] = value.split(':');
+  const hours = Number.parseInt(hoursStr ?? '', 10);
+  const minutes = Number.parseInt(minutesStr ?? '', 10);
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+    }
+    return value;
+  }
+  const display = new Date();
+  display.setHours(hours, minutes, 0, 0);
+  return display.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+};
+
+const TodoList = ({
+  todos,
+  completedArchive,
+  deletedArchive,
+  newTodo,
+  newDueDate,
+  newDueTime,
+  deletingId,
+  completingId,
+  isDarkMode,
+  latestArchivedId,
+  isLoading,
+  onNewTodoChange,
+  onDueDateChange,
+  onDueTimeChange,
+  onAddTodo,
+  onCompleteTodo,
+  onDeleteTodo,
+  onRestoreTodo,
+  onPermanentDelete,
+}: TodoListProps) => {
+  const [showArchive, setShowArchive] = useState(false);
+  const archiveCountRef = useRef(completedArchive.length + deletedArchive.length);
+
+  useEffect(() => {
+    const total = completedArchive.length + deletedArchive.length;
+    if (total > archiveCountRef.current) {
+      setShowArchive(true);
+    }
+    archiveCountRef.current = total;
+  }, [completedArchive.length, deletedArchive.length]);
+
+  const archiveSummary = useMemo(
+    () => ({
+      completed: completedArchive.length,
+      deleted: deletedArchive.length,
+    }),
+    [completedArchive.length, deletedArchive.length],
+  );
+
+  const totalArchived = archiveSummary.completed + archiveSummary.deleted;
+
+  const renderArchiveGroup = (
+    items: TodoItem[],
+    reason: ArchiveReason,
+    heading: string,
+    emptyCopy: string,
+  ) => {
+    const headingClass = isDarkMode ? 'text-indigo-100/80' : 'text-pink-900/80';
+    const descriptionClass = isDarkMode ? 'text-indigo-100/60' : 'text-pink-900/60';
+    const actionRestoreClass = isDarkMode
+      ? 'bg-indigo-500/30 text-indigo-100 hover:bg-indigo-500/50'
+      : 'bg-pink-500/20 text-pink-700 hover:bg-pink-500/30';
+    const actionDeleteClass = isDarkMode
+      ? 'text-indigo-200/70 hover:bg-indigo-500/20 hover:text-indigo-100'
+      : 'text-pink-700/70 hover:bg-pink-100/50 hover:text-pink-900';
+    const reasonLabel = reason === 'completed' ? 'Completed' : 'Deleted';
+
+    if (items.length === 0) {
+      return (
+        <div className="space-y-3">
+          <h3 className={`text-xs font-semibold uppercase tracking-[0.2em] ${headingClass}`}>{heading}</h3>
+          <p className={`text-sm ${descriptionClass}`}>{emptyCopy}</p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-3">
+        <h3 className={`text-xs font-semibold uppercase tracking-[0.2em] ${headingClass}`}>{heading}</h3>
+        {items.map((todo) => {
+          const archivedDate = formatDate(todo.archived_at ?? undefined);
+          const timeLabel = formatTime(todo.scheduled_time ?? (todo.due_at ?? undefined));
+          const highlightClass =
+            todo.id === latestArchivedId
+              ? isDarkMode
+                ? 'ring-2 ring-indigo-300/60 shadow-[0_0_18px_rgba(129,140,248,0.35)]'
+                : 'ring-2 ring-pink-300/70 shadow-[0_0_18px_rgba(236,72,153,0.28)]'
+              : '';
+
+          return (
+            <div
+              key={todo.id}
+              className={`flex flex-col gap-3 rounded-2xl border p-4 sm:flex-row sm:items-center sm:justify-between transition-shadow ${
+                isDarkMode
+                  ? 'border-white/10 bg-white/5 text-indigo-100'
+                  : 'border-white/20 bg-white/60 text-pink-900/80'
+              } ${highlightClass}`}
+            >
+              <div>
+                <p className="font-semibold">{todo.text}</p>
+                <p className={`text-xs ${descriptionClass}`}>
+                  {reasonLabel} • {archivedDate ?? 'Recently'}
+                  {timeLabel ? ` • ${timeLabel}` : ''}
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => onRestoreTodo(todo)}
+                  className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide transition ${actionRestoreClass}`}
+                >
+                  Restore
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onPermanentDelete(todo)}
+                  className={`flex h-8 w-8 items-center justify-center rounded-full transition ${actionDeleteClass}`}
+                  aria-label={`Delete ${todo.text} forever`}
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-4 w-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  const activeTaskCopy = todos.length === 0 ? 'No tasks yet — craft your next move above.' : undefined;
+
+  return (
+    <div className="animate-fadeIn">
+      <form onSubmit={onAddTodo} className="mb-8">
+        <div className="flex flex-col gap-3 md:flex-row">
+          <div className="flex flex-1 flex-col gap-3 sm:flex-row">
+            <input
+              type="text"
+              value={newTodo}
+              onChange={(event) => onNewTodoChange(event.target.value)}
+              placeholder="Add a new task..."
+              aria-label="Task description"
+              className={`w-full rounded-xl border p-3 placeholder:italic backdrop-blur-lg focus:outline-none focus:ring-2 ${
+                isDarkMode
+                  ? 'border-white/10 bg-white/5 text-indigo-100 placeholder:text-indigo-200/40 focus:ring-indigo-300/40'
+                  : 'border-white/20 bg-white/10 text-pink-900/90 placeholder:text-pink-700/60 focus:ring-white/40'
+              }`}
+            />
+            <div className="flex w-full gap-3 sm:w-auto">
+              <input
+                type="date"
+                value={newDueDate}
+                onChange={(event) => onDueDateChange(event.target.value)}
+                aria-label="Choose a due date"
+                className={`w-full rounded-xl border p-3 backdrop-blur-lg focus:outline-none focus:ring-2 sm:max-w-[200px] ${
+                  isDarkMode
+                    ? 'border-white/10 bg-white/5 text-indigo-100 focus:ring-indigo-300/40'
+                    : 'border-white/20 bg-white/10 text-pink-900/90 focus:ring-white/40'
+                }`}
+              />
+              <input
+                type="time"
+                value={newDueTime}
+                onChange={(event) => onDueTimeChange(event.target.value)}
+                aria-label="Choose a time"
+                className={`w-full rounded-xl border p-3 backdrop-blur-lg focus:outline-none focus:ring-2 sm:max-w-[150px] ${
+                  isDarkMode
+                    ? 'border-white/10 bg-white/5 text-indigo-100 focus:ring-indigo-300/40'
+                    : 'border-white/20 bg-white/10 text-pink-900/90 focus:ring-white/40'
+                }`}
+              />
+            </div>
+          </div>
+          <button
+            type="submit"
+            disabled={isLoading}
+            className={`rounded-xl border px-6 py-2 text-white shadow-lg backdrop-blur-lg transition-all duration-300 hover:shadow-[0_0_20px_rgba(236,72,153,0.4)] active:scale-95 ${
+              isDarkMode
+                ? 'border-violet-400/40 bg-gradient-to-r from-purple-500/80 to-indigo-500/80 hover:border-violet-300/60'
+                : 'border-white/20 bg-pink-600/80 hover:border-white/30 hover:bg-pink-700/90'
+            } disabled:cursor-not-allowed disabled:opacity-60`}
+            >
+            Add
+          </button>
+        </div>
+      </form>
+
+      {activeTaskCopy ? (
+        <div
+          className={`animate-fadeIn rounded-2xl border p-6 text-center backdrop-blur-lg ${
+            isDarkMode
+              ? 'border-white/10 bg-white/5 text-indigo-100'
+              : 'border-white/20 bg-white/40 text-pink-900/70'
+          }`}
+        >
+          {activeTaskCopy}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {todos.map((todo) => {
+            const dueDateLabel = formatDate(todo.due_at ?? todo.created_at);
+            const timeLabel = formatTime(todo.scheduled_time ?? (todo.due_at ?? undefined));
+            const animationClass =
+              completingId === todo.id
+                ? 'animate-rollComplete'
+                : deletingId === todo.id
+                ? 'animate-fadeOut'
+                : 'animate-fadeIn';
+            const baseClass = todo.completed
+              ? isDarkMode
+                ? 'border-emerald-400/30 bg-emerald-500/20 text-emerald-100'
+                : 'border-green-200/80 bg-green-100/70 text-green-900/90'
+              : isDarkMode
+              ? 'border-white/10 bg-white/5 text-indigo-100 hover:bg-white/10 hover:shadow-lg hover:shadow-indigo-500/10'
+              : 'border-white/20 bg-white/40 text-pink-900/90 hover:bg-white/60 hover:shadow-lg hover:shadow-pink-500/10';
+
+            return (
+              <div
+                key={todo.id}
+                className={`flex items-start rounded-2xl border p-4 backdrop-blur-lg transition-all duration-300 ${baseClass} ${animationClass}`}
+              >
+                <input
+                  type="checkbox"
+                  checked={todo.completed}
+                  onChange={() => onCompleteTodo(todo.id)}
+                  className={`mt-1 h-5 w-5 rounded-full border-2 transition-transform duration-200 focus:ring-2 ${
+                    isDarkMode
+                      ? 'border-indigo-300/50 text-indigo-200 focus:ring-indigo-300/40'
+                      : 'border-pink-200 text-pink-400 focus:ring-pink-300'
+                  }`}
+                  aria-label={`Mark ${todo.text} as complete`}
+                />
+                <div className="ml-3 flex-1">
+                  <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                    <p
+                      className={`font-medium transition-all duration-300 ${
+                        todo.completed ? 'line-through opacity-70' : ''
+                      }`}
+                    >
+                      {todo.text}
+                    </p>
+                    {timeLabel && (
+                      <span
+                        className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${
+                          isDarkMode
+                            ? 'bg-indigo-500/20 text-indigo-100'
+                            : 'bg-pink-500/15 text-pink-700/80'
+                        }`}
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          className="h-3 w-3"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={2}
+                        >
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                        {timeLabel}
+                      </span>
+                    )}
+                  </div>
+                  <p
+                    className={`mt-1 text-xs ${
+                      isDarkMode ? 'text-indigo-100/60' : 'text-pink-900/70'
+                    }`}
+                  >
+                    {todo.due_at ? 'Due' : 'Added'} {dueDateLabel ?? 'soon'}
+                  </p>
+                </div>
+                <button
+                  onClick={() => onDeleteTodo(todo.id)}
+                  className={`ml-3 rounded-lg p-1 transition-colors duration-200 ${
+                    isDarkMode
+                      ? 'text-indigo-200/70 hover:bg-indigo-500/20 hover:text-indigo-100'
+                      : 'text-pink-700/70 hover:bg-pink-100/50 hover:text-pink-900'
+                  }`}
+                  aria-label={`Delete ${todo.text}`}
+                  type="button"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-5 w-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                    />
+                  </svg>
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="mt-10 space-y-3">
+        <button
+          type="button"
+          onClick={() => setShowArchive((prev) => !prev)}
+          className={`flex w-full items-center justify-between rounded-2xl border px-4 py-3 text-left text-sm font-semibold uppercase tracking-[0.2em] backdrop-blur-lg ${
+            isDarkMode
+              ? 'border-white/10 bg-white/5 text-indigo-100 hover:bg-white/10'
+              : 'border-white/20 bg-white/40 text-pink-900/80 hover:bg-white/60'
+          }`}
+          aria-expanded={showArchive}
+        >
+          <span>Archive</span>
+          <span className="text-xs tracking-normal text-white/70">
+            {totalArchived} saved • {archiveSummary.completed} completed • {archiveSummary.deleted} deleted
+          </span>
+        </button>
+
+        {showArchive && (
+          <div
+            className={`animate-archiveReveal grid gap-3 rounded-2xl border p-5 backdrop-blur-lg ${
+              isDarkMode
+                ? 'border-white/10 bg-white/5'
+                : 'border-white/20 bg-white/30'
+            }`}
+          >
+            {totalArchived === 0 ? (
+              <p className={`text-sm ${isDarkMode ? 'text-indigo-100/70' : 'text-pink-900/70'}`}>
+                Nothing archived yet — complete or delete a task to see it celebrated here.
+              </p>
+            ) : (
+              <>
+                {renderArchiveGroup(
+                  completedArchive,
+                  'completed',
+                  'Completed',
+                  'No completed tasks in your archive yet — cross something off to celebrate it here.',
+                )}
+                {renderArchiveGroup(
+                  deletedArchive,
+                  'deleted',
+                  'Deleted',
+                  'No deleted tasks saved. Remove something to keep it handy for restoration or goodbye.',
+                )}
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TodoList;

--- a/src/index.css
+++ b/src/index.css
@@ -52,9 +52,21 @@
     0%, 100% { transform: scale(1); }
     50% { transform: scale(0.95); }
   }
+  @keyframes rollComplete {
+    0% { transform: rotateX(0deg) translateY(0); opacity: 1; }
+    35% { transform: rotateX(8deg) translateY(-4px); opacity: 1; }
+    70% { transform: rotateX(-4deg) translateY(8px); opacity: 0.85; }
+    100% { transform: rotateX(15deg) translateY(40px); opacity: 0; }
+  }
+  @keyframes archiveReveal {
+    from { opacity: 0; transform: translateY(12px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
   .animate-gradientMove { animation: gradientMove 12s ease-in-out infinite; }
   .animate-fadeIn { animation: fadeIn 0.4s ease-out; }
   .animate-fadeOut { animation: fadeOut 0.3s ease-in forwards; }
   .animate-fadeDown { animation: fadeDown 0.6s ease-out; }
   .animate-fadeUp { animation: fadeUp 0.6s ease-out; }
   .animate-completePulse { animation: completePulse 0.3s ease-in-out; }
+  .animate-rollComplete { animation: rollComplete 0.65s cubic-bezier(0.42, 0, 0.58, 1) forwards; }
+  .animate-archiveReveal { animation: archiveReveal 0.35s ease-out; }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,13 +14,13 @@ export interface RootTodo {
 export interface Assignment {
     id: number;
     description?: string;
-    due_at: string;
-    unlock_at: any;
-    lock_at: any;
+    due_at: string | null;
+    unlock_at: string | null;
+    lock_at: string | null;
     points_possible: number;
     grading_type: string;
     assignment_group_id: number;
-    grading_standard_id: any;
+    grading_standard_id: number | null;
     created_at: string;
     updated_at: string;
     peer_reviews: boolean;
@@ -28,7 +28,7 @@ export interface Assignment {
     position: number;
     grade_group_students_individually: boolean;
     anonymous_peer_reviews: boolean;
-    group_category_id: any;
+    group_category_id: number | null;
     post_to_sis: boolean;
     moderated_grading: boolean;
     omit_from_final_grade: boolean;
@@ -38,10 +38,10 @@ export interface Assignment {
     graders_anonymous_to_graders: boolean;
     grader_count: number;
     grader_comments_visible_to_graders: boolean;
-    final_grader_id: any;
+    final_grader_id: number | null;
     grader_names_visible_to_final_grader: boolean;
     allowed_attempts: number;
-    annotatable_attachment_id: any;
+    annotatable_attachment_id: number | null;
     hide_in_gradebook: boolean;
     suppress_assignment: boolean;
     secure_params: string;
@@ -56,11 +56,11 @@ export interface Assignment {
     graded_submissions_exist: boolean;
     is_quiz_assignment: boolean;
     can_duplicate: boolean;
-    original_course_id: any;
-    original_assignment_id: any;
-    original_lti_resource_link_id: any;
-    original_assignment_name: any;
-    original_quiz_id: any;
+    original_course_id: number | null;
+    original_assignment_id: number | null;
+    original_lti_resource_link_id: string | null;
+    original_assignment_name: string | null;
+    original_quiz_id: number | null;
     workflow_state: string;
     important_dates: boolean;
     muted: boolean;
@@ -81,9 +81,9 @@ export interface Assignment {
 
 export interface AllDate {
     id: number;
-    due_at: string;
-    unlock_at: any;
-    lock_at: any;
+    due_at: string | null;
+    unlock_at: string | null;
+    lock_at: string | null;
     title: string;
     set_type: string;
     set_id: number;
@@ -100,5 +100,32 @@ export interface ContextModule {
     context_type: string;
     context_id: number;
     workflow_state: string;
-    unlock_at: string;
+    unlock_at: string | null;
+}
+
+export type TodoOrigin = 'canvas' | 'manual';
+
+export type ArchiveReason = 'completed' | 'deleted';
+
+export interface TodoItem {
+    id: number;
+    text: string;
+    due_at?: string | null;
+    created_at?: string;
+    completed: boolean;
+    origin?: TodoOrigin;
+    external_id?: number | null;
+    scheduled_time?: string | null;
+    archived_at?: string | null;
+    archived_reason?: ArchiveReason;
+}
+
+export interface PlannerArchiveBuckets {
+    completed: TodoItem[];
+    deleted: TodoItem[];
+}
+
+export interface PlannerStatePayload {
+    active: TodoItem[];
+    archive: PlannerArchiveBuckets;
 }


### PR DESCRIPTION
## Summary
- replace the localStorage mock with a real SQLite schema and Express API so Canvas and manual todos live in the same database and archive events are recorded
- teach the React app to hydrate from the new planner endpoints, add dark mode and slider transitions, and keep completed vs deleted drawers with restore or permanent delete confirmations
- flesh out the calendar and todo list components with scheduling inputs, archive trays, and refined styling, and tighten the Canvas assignment typings to satisfy lint

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9e53f3acc8332bf17687dd85420ed