### PR TITLE
Stabilize planner rendering and agent scroll behavior

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,6 +109,33 @@ const usePrefersDarkScheme = (initialValue: boolean) =>
     () => initialValue,
   );
 
+const todoListsEqual = (a: TodoItem[], b: TodoItem[]) => {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+
+  for (let index = 0; index < a.length; index += 1) {
+    const left = a[index];
+    const right = b[index];
+
+    if (
+      left.id !== right.id ||
+      left.text !== right.text ||
+      left.due_at !== right.due_at ||
+      left.created_at !== right.created_at ||
+      left.completed !== right.completed ||
+      left.origin !== right.origin ||
+      left.external_id !== right.external_id ||
+      left.scheduled_time !== right.scheduled_time ||
+      left.archived_at !== right.archived_at ||
+      left.archived_reason !== right.archived_reason
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
 const App = () => {
   const initialTheme = useMemo(() => getInitialThemeSettings(), []);
   const [activeTodos, setActiveTodos] = useState<TodoItem[]>([]);
@@ -127,14 +154,15 @@ const App = () => {
   const prefersDarkScheme = usePrefersDarkScheme(initialTheme.isDark);
   const isDarkMode = themeMode === 'dark' || (themeMode === 'system' && prefersDarkScheme);
 
-  const applyPlannerState = useCallback(
-    (state: PlannerStatePayload) => {
-      setActiveTodos(state.active ?? []);
-      setCompletedArchive(state.archive?.completed ?? []);
-      setDeletedArchive(state.archive?.deleted ?? []);
-    },
-    [],
-  );
+  const applyPlannerState = useCallback((state: PlannerStatePayload) => {
+    const nextActive = state.active ?? [];
+    const nextCompleted = state.archive?.completed ?? [];
+    const nextDeleted = state.archive?.deleted ?? [];
+
+    setActiveTodos((current) => (todoListsEqual(current, nextActive) ? current : nextActive));
+    setCompletedArchive((current) => (todoListsEqual(current, nextCompleted) ? current : nextCompleted));
+    setDeletedArchive((current) => (todoListsEqual(current, nextDeleted) ? current : nextDeleted));
+  }, []);
 
   const loadPlannerState = useCallback(
     async (options?: { sync?: boolean }) => {

--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -320,7 +320,7 @@ const AgentPanel = ({ isDarkMode, activeTodos, completedTodos, isLoading }: Agen
 
   const [messages, setMessages] = useState<AgentMessage[]>(() => buildDemoTranscript(summary));
   const [hasUserInteracted, setHasUserInteracted] = useState(false);
-  const scrollAnchorRef = useRef<HTMLDivElement | null>(null);
+  const messagesContainerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (hasUserInteracted) return;
@@ -328,8 +328,14 @@ const AgentPanel = ({ isDarkMode, activeTodos, completedTodos, isLoading }: Agen
   }, [summary, hasUserInteracted]);
 
   useEffect(() => {
-    scrollAnchorRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages]);
+    const container = messagesContainerRef.current;
+    if (!container) return;
+
+    container.scrollTo({
+      top: container.scrollHeight,
+      behavior: hasUserInteracted ? 'smooth' : 'auto',
+    });
+  }, [messages, hasUserInteracted]);
 
   const panelClass = isDarkMode
     ? 'border-white/10 bg-black/40 text-indigo-50'
@@ -608,7 +614,12 @@ const AgentPanel = ({ isDarkMode, activeTodos, completedTodos, isLoading }: Agen
           </div>
         </header>
 
-        <div className="flex-1 space-y-5 overflow-y-auto px-6 py-6" role="log" aria-live="polite">
+        <div
+          ref={messagesContainerRef}
+          className="flex-1 space-y-5 overflow-y-auto px-6 py-6"
+          role="log"
+          aria-live="polite"
+        >
           {messages.map((message) => {
             if (message.kind === 'widget') {
               return (
@@ -636,7 +647,6 @@ const AgentPanel = ({ isDarkMode, activeTodos, completedTodos, isLoading }: Agen
               </div>
             );
           })}
-          <div ref={scrollAnchorRef} />
         </div>
 
         <form

--- a/src/index.css
+++ b/src/index.css
@@ -19,7 +19,7 @@
 }
 
 /* Smooth transitions */
-* {
+body {
   @apply transition-colors duration-200;
 }
 


### PR DESCRIPTION
## Summary
- avoid replacing todo lists when the payload is unchanged to eliminate redundant rerenders
- keep the agent transcript auto-scroll inside the panel instead of the full page
- limit global color transitions to the body to reduce flashing when toggling themes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb294cf4cc8332b12f4a946e292654